### PR TITLE
Make fields required but undefinedable

### DIFF
--- a/build/lib/template/partial/message.hbs
+++ b/build/lib/template/partial/message.hbs
@@ -35,7 +35,7 @@
 {{{../indent}}}    set{{{formatName this.camelUpperName}}}(value: Uint8Array | string): {{{../message.messageName}}};
             {{~else~}}
 {{{../indent}}}    get{{{formatName this.camelUpperName}}}(): {{{this.exportType}}}{{#if this.canBeUndefined}} | undefined{{/if}};
-{{{../indent}}}    set{{{formatName this.camelUpperName}}}(value{{#is this.type ../MESSAGE_TYPE}}?{{/is}}: {{{this.exportType}}}): {{{../message.messageName}}};
+{{{../indent}}}    set{{{formatName this.camelUpperName}}}(value: {{{this.exportType}}}{{#is this.type ../MESSAGE_TYPE}} | undefined{{/is}}): {{{../message.messageName}}};
             {{~/is~}}
         {{~/if~}}{{!-- repeat end --}}
     {{~/if~}}{{!-- map spec end --}}
@@ -72,7 +72,7 @@
             {{~#is this.type ../BYTES_TYPE~}}
 {{{../indent}}}        {{{this.camelCaseName}}}: Uint8Array | string,
             {{~else~}}
-{{{../indent}}}        {{{this.camelCaseName}}}{{~#if this.canBeUndefined~}}?{{~/if~}}: {{{this.fieldObjectType}}},
+{{{../indent}}}        {{{this.camelCaseName}}}: {{{this.fieldObjectType}}}{{~#if this.canBeUndefined~}} | undefined{{~/if~}},
             {{~/is~}}
         {{~/if~}}{{!-- repeat end --}}
     {{~/if~}}{{!-- map spec end --}}

--- a/build/lib/template/partial/message.hbs
+++ b/build/lib/template/partial/message.hbs
@@ -35,7 +35,7 @@
 {{{../indent}}}    set{{{formatName this.camelUpperName}}}(value: Uint8Array | string): {{{../message.messageName}}};
             {{~else~}}
 {{{../indent}}}    get{{{formatName this.camelUpperName}}}(): {{{this.exportType}}}{{#if this.canBeUndefined}} | undefined{{/if}};
-{{{../indent}}}    set{{{formatName this.camelUpperName}}}(value: {{{this.exportType}}}{{#is this.type ../MESSAGE_TYPE}} | undefined{{/is}}): {{{../message.messageName}}};
+{{{../indent}}}    set{{{formatName this.camelUpperName}}}(value{{#is this.type ../MESSAGE_TYPE}}?{{/is}}: {{{this.exportType}}}): {{{../message.messageName}}};
             {{~/is~}}
         {{~/if~}}{{!-- repeat end --}}
     {{~/if~}}{{!-- map spec end --}}
@@ -72,7 +72,7 @@
             {{~#is this.type ../BYTES_TYPE~}}
 {{{../indent}}}        {{{this.camelCaseName}}}: Uint8Array | string,
             {{~else~}}
-{{{../indent}}}        {{{this.camelCaseName}}}: {{{this.fieldObjectType}}}{{~#if this.canBeUndefined~}} | undefined{{~/if~}},
+{{{../indent}}}        {{{this.camelCaseName}}}{{~#if this.canBeUndefined~}}?{{~/if~}}: {{{this.fieldObjectType}}},
             {{~/is~}}
         {{~/if~}}{{!-- repeat end --}}
     {{~/if~}}{{!-- map spec end --}}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@faire/grpc_tools_node_protoc_ts",
-  "version": "5.1.3",
+  "version": "5.1.5",
   "description": "Generate d.ts definitions for generated js files from grpc_tools_node_protoc",
   "main": "build/index.js",
   "scripts": {

--- a/src/lib/template/partial/message.hbs
+++ b/src/lib/template/partial/message.hbs
@@ -35,7 +35,7 @@
 {{{../indent}}}    set{{{formatName this.camelUpperName}}}(value: Uint8Array | string): {{{../message.messageName}}};
             {{~else~}}
 {{{../indent}}}    get{{{formatName this.camelUpperName}}}(): {{{this.exportType}}}{{#if this.canBeUndefined}} | undefined{{/if}};
-{{{../indent}}}    set{{{formatName this.camelUpperName}}}(value{{#is this.type ../MESSAGE_TYPE}}?{{/is}}: {{{this.exportType}}}): {{{../message.messageName}}};
+{{{../indent}}}    set{{{formatName this.camelUpperName}}}(value: {{{this.exportType}}}{{#is this.type ../MESSAGE_TYPE}} | undefined{{/is}}): {{{../message.messageName}}};
             {{~/is~}}
         {{~/if~}}{{!-- repeat end --}}
     {{~/if~}}{{!-- map spec end --}}
@@ -72,7 +72,7 @@
             {{~#is this.type ../BYTES_TYPE~}}
 {{{../indent}}}        {{{this.snakeCaseName}}}: Uint8Array | string,
             {{~else~}}
-{{{../indent}}}        {{{this.snakeCaseName}}}{{~#if this.canBeUndefined~}}?{{~/if~}}: {{{this.fieldObjectType}}},
+{{{../indent}}}        {{{this.snakeCaseName}}}: {{{this.fieldObjectType}}}{{~#if this.canBeUndefined~}} | undefined{{~/if~}},
             {{~/is~}}
         {{~/if~}}{{!-- repeat end --}}
     {{~/if~}}{{!-- map spec end --}}

--- a/src/lib/template/partial/message.hbs
+++ b/src/lib/template/partial/message.hbs
@@ -72,7 +72,7 @@
             {{~#is this.type ../BYTES_TYPE~}}
 {{{../indent}}}        {{{this.snakeCaseName}}}: Uint8Array | string,
             {{~else~}}
-{{{../indent}}}        {{{this.snakeCaseName}}}: {{{this.fieldObjectType}}}{{~#if this.canBeUndefined~}} | undefined{{~/if~}},
+{{{../indent}}}        {{{this.snakeCaseName}}}: {{{this.fieldObjectType}}}{{~#if this.canBeUndefined}} | undefined{{~/if~}},
             {{~/is~}}
         {{~/if~}}{{!-- repeat end --}}
     {{~/if~}}{{!-- map spec end --}}


### PR DESCRIPTION
Not tested. Please top-hat test.

I've verified that this fixes our casting problems on service interfaces, but it may cause issues inside the engine for anything that's creating an object (although, I'm confident the inferred types don't have a lot to do with the code that actually builds things).