### PR TITLE
[FD-133951] Remove .npmrc file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ jspm_packages/
 
 # Optional npm cache directory
 .npm
+.npmrc
 
 # Optional eslint cache
 .eslintcache

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-//verdaccio.faire.team/:_authToken=${VERDACCIO_TOKEN}
-//verdaccio.faire.team/:always-auth=true
-registry=https://verdaccio.faire.team/


### PR DESCRIPTION
## Why is this change needed?

The repo-level `.npmrc` is being removed since it conflicts with the updated local Verdaccio setup.

Design doc: https://docs.google.com/document/d/11Z0Y8k6aY-5PAll-nEXS84_v7zqXvuJWD8NxaQK9cgM/edit?usp=sharing
Jira ticket: https://fairewholesale.atlassian.net/browse/FD-133951

<!-- Remember to include JIRA Reference! (ie. "FD-1234 Fix the thing") -->

## What does this change do?

- Removes the repo-level `.npmrc` file